### PR TITLE
add the option to specify the family per rule to support ipv6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,22 @@ Allow access from local network
                   source_network: 192.168.1.0/24
                   jump: ACCEPT
 
+IPv6 is supported as well
+		
+.. code-block:: yaml
+
+    parameters:
+      iptables:
+        service:
+          chain:
+            INPUT:
+              rules:
+                - protocol: tcp
+		  family: ipv6
+                  destination_port: 22
+                  source_network: 2001:DB8::/32
+                  jump: ACCEPT
+		  
 Read more
 =========
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ ping
     parametetrs:
       iptables:
         service:
+          enabled: True
           chain:
             INPUT:
               rules:
@@ -89,21 +90,23 @@ Allow access from local network
                   jump: ACCEPT
 
 IPv6 is supported as well
-		
+
 .. code-block:: yaml
 
     parameters:
       iptables:
         service:
+          enabled: True
+          ipv6: True
           chain:
             INPUT:
               rules:
                 - protocol: tcp
-		  family: ipv6
+                  family: ipv6
                   destination_port: 22
                   source_network: 2001:DB8::/32
                   jump: ACCEPT
-		  
+
 Read more
 =========
 

--- a/iptables/_rule.sls
+++ b/iptables/_rule.sls
@@ -11,6 +11,9 @@ iptables_{{ chain_name }}_{{ rule_name }}:
   {%- endif %}
   - table: {{ rule.get('table', 'filter') }}
   - chain: {{ chain_name }}
+  {%- if rule.family is defined %}
+  - family: {{ rule.family }}
+  {%- endif %}
   {%- if rule.jump is defined %}
   - jump: {{ rule.jump }}
   {%- endif %}

--- a/iptables/rules.sls
+++ b/iptables/rules.sls
@@ -5,6 +5,14 @@
 {%- if chain.policy is defined %}
 iptables_{{ chain_name }}_policy:
   iptables.set_policy:
+    - family: ipv4
+    - chain: {{ chain_name }}
+    - policy: {{ chain.policy }}
+    - table: filter
+
+iptables_{{ chain_name }}_ipv6_policy:
+  iptables.set_policy:
+    - family: ipv6
     - chain: {{ chain_name }}
     - policy: {{ chain.policy }}
     - table: filter

--- a/iptables/rules.sls
+++ b/iptables/rules.sls
@@ -10,7 +10,7 @@ iptables_{{ chain_name }}_policy:
     - policy: {{ chain.policy }}
     - table: filter
 
-{%-   if service.ipv6 %}
+{%-   if grains.ipv6|default(False) and service.ipv6|default(True) %}
 iptables_{{ chain_name }}_ipv6_policy:
   iptables.set_policy:
     - family: ipv6

--- a/iptables/rules.sls
+++ b/iptables/rules.sls
@@ -10,12 +10,14 @@ iptables_{{ chain_name }}_policy:
     - policy: {{ chain.policy }}
     - table: filter
 
+{%-   if service.ipv6 %}
 iptables_{{ chain_name }}_ipv6_policy:
   iptables.set_policy:
     - family: ipv6
     - chain: {{ chain_name }}
     - policy: {{ chain.policy }}
     - table: filter
+{%-   endif %}
 {%- endif %}
 
 {%- for service_name, service in pillar.items() %}

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -37,7 +37,7 @@ iptables_{{ chain_name }}_policy:
     - require_in:
       - iptables: iptables_flush
 
-{%-   if service.ipv6 %}
+{%-   if grains.ipv6|default(False) and service.ipv6|default(True) %}
 iptables_{{ chain_name }}_ipv6_policy:
   iptables.set_policy:
     - chain: {{ chain_name }}
@@ -53,7 +53,7 @@ iptables_{{ chain_name }}_ipv6_policy:
 iptables_flush:
   iptables.flush
 
-{%- if service.ipv6 %}
+{%- if grains.ipv6|default(False) and service.ipv6|default(True) %}
 ip6tables_flush:
   iptables.flush:
     - family: ipv6

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -36,9 +36,22 @@ iptables_{{ chain_name }}_policy:
     - table: filter
     - require_in:
       - iptables: iptables_flush
+
+iptables_{{ chain_name }}_ipv6_policy:
+  iptables.set_policy:
+    - chain: {{ chain_name }}
+    - family: ipv6
+    - policy: ACCEPT
+    - table: filter
+    - require_in:
+      - iptables: ip6tables_flush
 {%- endfor %}
 
 iptables_flush:
   iptables.flush
+
+ip6tables_flush:
+  iptables.flush:
+    - family: ipv6
 
 {%- endif %}

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -37,6 +37,7 @@ iptables_{{ chain_name }}_policy:
     - require_in:
       - iptables: iptables_flush
 
+{%-   if service.ipv6 %}
 iptables_{{ chain_name }}_ipv6_policy:
   iptables.set_policy:
     - chain: {{ chain_name }}
@@ -45,13 +46,18 @@ iptables_{{ chain_name }}_ipv6_policy:
     - table: filter
     - require_in:
       - iptables: ip6tables_flush
+{%-   endif %}
+
 {%- endfor %}
 
 iptables_flush:
   iptables.flush
 
+{%- if service.ipv6 %}
 ip6tables_flush:
   iptables.flush:
     - family: ipv6
+{%- endif %}
+
 
 {%- endif %}


### PR DESCRIPTION
This update adds the ability to specify the protocol family. Here's an example:

```yaml
  iptables:
    service:
      enabled: True
      chain:
        INPUT:
          policy: DROP
          rules:
            - protocol: tcp
              family: ipv4
              source_network: 192.0.2.0/24
              jump: ACCEPT
            - protocol: tcp
              family: ipv6
              source_network: 2001:DB8::/32
              jump: ACCEPT
```
