### PR TITLE
Add support for using iptables-restore to apply the rules

### DIFF
--- a/iptables/files/ip4tables
+++ b/iptables/files/ip4tables
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# This file is part of netfilter-persistent
+# (was iptables-persistent)
+# Copyright (C) 2009, Simon Richter <sjr@debian.org>
+# Copyright (C) 2010, 2014 Jonathan Wiltshire <jmw@debian.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+
+rc=0
+
+load_rules()
+{
+	#load IPv4 rules
+	if [ ! -f /etc/iptables/rules.v4 ]; then
+		echo "Warning: skipping IPv4 (no rules to load)"
+	else
+{%- if provider == 'iptables-restore' %}
+		iptables-restore --test < /etc/iptables/rules.v4 2> /dev/null
+		if [ $? -ne 0 ]; then
+			rc=1
+		else
+			iptables-save > /etc/iptables/rules.v4.bak
+			grep -v __saltstack__ /etc/iptables/rules.v4.bak | iptables-restore 2> /dev/null
+			iptables-restore --noflush < /etc/iptables/rules.v4 2> /dev/null
+			if [ $? -ne 0 ]; then
+				rc=1
+				iptables-restore < /etc/iptables/rules.v4.bak 2> /dev/null
+			fi
+		fi
+{%- else %}
+		iptables-restore < /etc/iptables/rules.v4 2> /dev/null
+		if [ $? -ne 0 ]; then
+			rc=1
+		fi
+{%- endif %}
+	fi
+}
+
+save_rules()
+{
+	#save IPv4 rules
+	#need at least iptable_filter loaded:
+	/sbin/modprobe -q iptable_filter
+	if [ ! -f /proc/net/ip_tables_names ]; then
+		echo "Warning: skipping IPv4 (no modules loaded)"
+	elif [ -x /sbin/iptables-save ]; then
+		touch /etc/iptables/rules.v4
+		chmod 0640 /etc/iptables/rules.v4
+		iptables-save > /etc/iptables/rules.v4
+		if [ $? -ne 0 ]; then
+			rc=1
+		fi
+	fi
+}
+
+flush_rules()
+{
+	if [ ! -f /proc/net/ip_tables_names ]; then
+		log_action_cont_msg "Warning: skipping IPv4 (no module loaded)"
+	elif [ -x /sbin/iptables ]; then
+		for param in F Z X; do /sbin/iptables -$param; done
+		for table in $(cat /proc/net/ip_tables_names)
+		do
+			/sbin/iptables -t $table -F
+			/sbin/iptables -t $table -Z
+			/sbin/iptables -t $table -X
+		done
+		for chain in INPUT FORWARD OUTPUT
+		do
+			/sbin/iptables -P $chain ACCEPT
+		done
+	fi
+}
+
+case "$1" in
+start|restart|reload|force-reload)
+	load_rules
+	;;
+save)
+	save_rules
+	;;
+stop)
+	# Why? because if stop is used, the firewall gets flushed for a variable
+	# amount of time during package upgrades, leaving the machine vulnerable
+	# It's also not always desirable to flush during purge
+	echo "Automatic flushing disabled, use \"flush\" instead of \"stop\""
+	;;
+flush)
+	flush_rules
+	;;
+*)
+	echo "Usage: $0 {start|restart|reload|force-reload|save|flush}" >&2
+	exit 1
+	;;
+esac
+
+exit $rc

--- a/iptables/files/ip6tables
+++ b/iptables/files/ip6tables
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# This file is part of netfilter-persistent
+# (was iptables-persistent)
+# Copyright (C) 2009, Simon Richter <sjr@debian.org>
+# Copyright (C) 2010, 2014 Jonathan Wiltshire <jmw@debian.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+
+rc=0
+
+load_rules()
+{
+	#load IPv6 rules
+	if [ ! -f /etc/iptables/rules.v6 ]; then
+		echo "Warning: skipping IPv6 (no rules to load)"
+	else
+{%- if provider == 'iptables-restore' %}
+		ip6tables-restore --test < /etc/iptables/rules.v6 2> /dev/null
+		if [ $? -ne 0 ]; then
+			rc=1
+		else
+			ip6tables-save > /etc/iptables/rules.v6.bak
+			grep -v __saltstack__ /etc/iptables/rules.v6.bak | ip6tables-restore 2> /dev/null
+			ip6tables-restore --noflush < /etc/iptables/rules.v6 2> /dev/null
+			if [ $? -ne 0 ]; then
+				rc=1
+				ip6tables-restore < /etc/iptables/rules.v6.bak 2> /dev/null
+			fi
+		fi
+{%- else %}
+		ip6tables-restore < /etc/iptables/rules.v6 2> /dev/null
+		if [ $? -ne 0 ]; then
+			rc=1
+		fi
+{%- endif %}
+	fi
+}
+
+save_rules()
+{
+	#save IPv6 rules
+	#need at least ip6table_filter loaded:
+	/sbin/modprobe -q ip6table_filter
+	if [ ! -f /proc/net/ip6_tables_names ]; then
+		log_action_cont_msg "Warning: skipping IPv6 (no modules loaded)"
+	elif [ -x /sbin/ip6tables-save ]; then
+		touch /etc/iptables/rules.v6
+		chmod 0640 /etc/iptables/rules.v6
+		ip6tables-save > /etc/iptables/rules.v6
+		if [ $? -ne 0 ]; then
+			rc=1
+		fi
+	fi
+}
+
+flush_rules()
+{
+	if [ ! -f /proc/net/ip6_tables_names ]; then
+		echo "Warning: skipping IPv6 (no module loaded)"
+	elif [ -x /sbin/ip6tables ]; then
+		for param in F Z X; do /sbin/ip6tables -$param; done
+		for table in $(cat /proc/net/ip6_tables_names)
+		do
+			/sbin/ip6tables -t $table -F
+			/sbin/ip6tables -t $table -Z
+			/sbin/ip6tables -t $table -X
+		done
+		for chain in INPUT FORWARD OUTPUT
+		do
+			/sbin/ip6tables -P $chain ACCEPT
+		done
+	fi
+}
+
+case "$1" in
+start|restart|reload|force-reload)
+	load_rules
+	;;
+save)
+	save_rules
+	;;
+stop)
+	# Why? because if stop is used, the firewall gets flushed for a variable
+	# amount of time during package upgrades, leaving the machine vulnerable
+	# It's also not always desirable to flush during purge
+	echo "Automatic flushing disabled, use \"flush\" instead of \"stop\""
+	;;
+flush)
+	flush_rules
+	;;
+*)
+	echo "Usage: $0 {start|restart|reload|force-reload|save|flush}" >&2
+	exit 1
+	;;
+esac
+
+exit $rc

--- a/iptables/files/rules.v4
+++ b/iptables/files/rules.v4
@@ -1,83 +1,17 @@
 # This file is managed by SaltStack
+{%- for table in ['mangle', 'nat', 'filter'] %}
 
-*filter
-{%- for chain_name, chain in chains.iteritems() %}
-:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
-{%- endfor %}
-
-{%- for chain_name, chain in chains.iteritems() %}
-{%- for rule in meta_rules + chain.rules %}
-{%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv4' %}
-{%- set r = {
-  'full': 'True',
-  'table': 'filter',
-  'chain': chain_name.upper(),
-  'command': 'A',
-  'family': 'ipv4',
-  'comment': rule.get('comment', '') + '__saltstack__',
-} %}
-{%- if rule.position is defined %}
-{%- do r.update({
-  'command': 'I',
-  'position': rule['position'],
-}) %}
-{%- endif %}
-{%- if rule.jump is defined %}
-{%- do r.update({'jump': rule.jump}) %}
-{%- endif %}
-{%- if rule.match is defined %}
-{%- do r.update({'match': rule.match}) %}
-{%- endif %}
-{%- if rule.connection_state is defined %}
-{%- do r.update({'connstate': rule.connection_state}) %}
-{%- endif %}
-{%- if rule.protocol is defined %}
-{%- do r.update({'proto': rule.protocol}) %}
-{%- endif %}
-{%- if rule.destination_port is defined %}
-{%- do r.update({'dport': rule.destination_port}) %}
-{%- endif %}
-{%- if rule.source_port is defined %}
-{%- do r.update({'sport': rule.source_port}) %}
-{%- endif %}
-{%- if rule.in_interface is defined %}
-{%- do r.update({'in-interface': rule.in_interface}) %}
-{%- endif %}
-{%- if rule.out_interface is defined %}
-{%- do r.update({'out-interface': rule.out_interface}) %}
-{%- endif %}
-{%- if rule.to_destination is defined %}
-{%- do r.update({'to-destination': rule.to_destination}) %}
-{%- endif %}
-{%- if rule.to_port is defined %}
-{%- do r.update({'to-port': rule.to_port}) %}
-{%- endif %}
-{%- if rule.to_source is defined %}
-{%- do r.update({'to-source': rule.to_source}) %}
-{%- endif %}
-{%-  if rule.source_network is defined %}
-{%- do r.update({'source': rule.source_network}) %}
-{%- endif %}
-{%-  if rule.destination_network is defined %}
-{%- do r.update({'destination': rule.destination_network}) %}
-{%- endif %}
-{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t filter ', '') }}
-{%- endif %}
-{%- endfor %}
-{%- endfor %}
-COMMIT
-
-*nat
+*{{ table }}
 {%- for chain_name, chain in chains.iteritems() %}
 :{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
 {%- endfor %}
 
 {%- for chain_name, chain in chains.iteritems() %}
 {%- for rule in chain.rules %}
-{%- if rule.get('table', 'filter').lower() == 'nat' and rule.get('family', 'ipv4') == 'ipv4' %}
+{%- if rule.get('table', 'filter').lower() == table and rule.get('family', 'ipv4') == 'ipv4' %}
 {%- set r = {
   'full': 'True',
-  'table': 'nat',
+  'table': table,
   'chain': chain_name.upper(),
   'command': 'A',
   'family': 'ipv4',
@@ -122,14 +56,21 @@ COMMIT
 {%- if rule.to_source is defined %}
 {%- do r.update({'to-source': rule.to_source}) %}
 {%- endif %}
-{%-  if rule.source_network is defined %}
+{%- if rule.source_network is defined %}
 {%- do r.update({'source': rule.source_network}) %}
 {%- endif %}
-{%-  if rule.destination_network is defined %}
+{%- if rule.destination_network is defined %}
 {%- do r.update({'destination': rule.destination_network}) %}
 {%- endif %}
-{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t nat ', '') }}
+{%- if rule.mark is defined %}
+{%- do r.update({'mark': rule.mark}) %}
+{%- endif %}
+{%- if rule.set_mark is defined %}
+{%- do r.update({'set-mark': rule.set_mark}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t %s ' % table, '') }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
 COMMIT
+{%- endfor %}

--- a/iptables/files/rules.v4
+++ b/iptables/files/rules.v4
@@ -6,7 +6,7 @@
 {%- endfor %}
 
 {%- for chain_name, chain in chains.iteritems() %}
-{%- for rule in chain.rules %}
+{%- for rule in meta_rules + chain.rules %}
 {%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv4' %}
 {%- set r = {
   'full': 'True',

--- a/iptables/files/rules.v4
+++ b/iptables/files/rules.v4
@@ -1,0 +1,135 @@
+# This file is managed by SaltStack
+
+*filter
+{%- for chain_name, chain in chains.iteritems() %}
+:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
+{%- endfor %}
+
+{%- for chain_name, chain in chains.iteritems() %}
+{%- for rule in chain.rules %}
+{%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv4' %}
+{%- set r = {
+  'full': 'True',
+  'table': 'filter',
+  'chain': chain_name.upper(),
+  'command': 'A',
+  'family': 'ipv4',
+  'comment': rule.get('comment', '') + '__saltstack__',
+} %}
+{%- if rule.position is defined %}
+{%- do r.update({
+  'command': 'I',
+  'position': rule['position'],
+}) %}
+{%- endif %}
+{%- if rule.jump is defined %}
+{%- do r.update({'jump': rule.jump}) %}
+{%- endif %}
+{%- if rule.match is defined %}
+{%- do r.update({'match': rule.match}) %}
+{%- endif %}
+{%- if rule.connection_state is defined %}
+{%- do r.update({'connstate': rule.connection_state}) %}
+{%- endif %}
+{%- if rule.protocol is defined %}
+{%- do r.update({'proto': rule.protocol}) %}
+{%- endif %}
+{%- if rule.destination_port is defined %}
+{%- do r.update({'dport': rule.destination_port}) %}
+{%- endif %}
+{%- if rule.source_port is defined %}
+{%- do r.update({'sport': rule.source_port}) %}
+{%- endif %}
+{%- if rule.in_interface is defined %}
+{%- do r.update({'in-interface': rule.in_interface}) %}
+{%- endif %}
+{%- if rule.out_interface is defined %}
+{%- do r.update({'out-interface': rule.out_interface}) %}
+{%- endif %}
+{%- if rule.to_destination is defined %}
+{%- do r.update({'to-destination': rule.to_destination}) %}
+{%- endif %}
+{%- if rule.to_port is defined %}
+{%- do r.update({'to-port': rule.to_port}) %}
+{%- endif %}
+{%- if rule.to_source is defined %}
+{%- do r.update({'to-source': rule.to_source}) %}
+{%- endif %}
+{%-  if rule.source_network is defined %}
+{%- do r.update({'source': rule.source_network}) %}
+{%- endif %}
+{%-  if rule.destination_network is defined %}
+{%- do r.update({'destination': rule.destination_network}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t filter ', '') }}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+COMMIT
+
+*nat
+{%- for chain_name, chain in chains.iteritems() %}
+:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
+{%- endfor %}
+
+{%- for chain_name, chain in chains.iteritems() %}
+{%- for rule in chain.rules %}
+{%- if rule.get('table', 'filter').lower() == 'nat' and rule.get('family', 'ipv4') == 'ipv4' %}
+{%- set r = {
+  'full': 'True',
+  'table': 'nat',
+  'chain': chain_name.upper(),
+  'command': 'A',
+  'family': 'ipv4',
+  'comment': rule.get('comment', '') + '__saltstack__',
+} %}
+{%- if rule.position is defined %}
+{%- do r.update({
+  'command': 'I',
+  'position': rule['position'],
+}) %}
+{%- endif %}
+{%- if rule.jump is defined %}
+{%- do r.update({'jump': rule.jump}) %}
+{%- endif %}
+{%- if rule.match is defined %}
+{%- do r.update({'match': rule.match}) %}
+{%- endif %}
+{%- if rule.connection_state is defined %}
+{%- do r.update({'connstate': rule.connection_state}) %}
+{%- endif %}
+{%- if rule.protocol is defined %}
+{%- do r.update({'proto': rule.protocol}) %}
+{%- endif %}
+{%- if rule.destination_port is defined %}
+{%- do r.update({'dport': rule.destination_port}) %}
+{%- endif %}
+{%- if rule.source_port is defined %}
+{%- do r.update({'sport': rule.source_port}) %}
+{%- endif %}
+{%- if rule.in_interface is defined %}
+{%- do r.update({'in-interface': rule.in_interface}) %}
+{%- endif %}
+{%- if rule.out_interface is defined %}
+{%- do r.update({'out-interface': rule.out_interface}) %}
+{%- endif %}
+{%- if rule.to_destination is defined %}
+{%- do r.update({'to-destination': rule.to_destination}) %}
+{%- endif %}
+{%- if rule.to_port is defined %}
+{%- do r.update({'to-port': rule.to_port}) %}
+{%- endif %}
+{%- if rule.to_source is defined %}
+{%- do r.update({'to-source': rule.to_source}) %}
+{%- endif %}
+{%-  if rule.source_network is defined %}
+{%- do r.update({'source': rule.source_network}) %}
+{%- endif %}
+{%-  if rule.destination_network is defined %}
+{%- do r.update({'destination': rule.destination_network}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t nat ', '') }}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+COMMIT

--- a/iptables/files/rules.v6
+++ b/iptables/files/rules.v6
@@ -1,83 +1,17 @@
 # This file is managed by SaltStack
+{%- for table in ['mangle', 'nat', 'filter'] %}
 
-*filter
-{%- for chain_name, chain in chains.iteritems() %}
-:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
-{%- endfor %}
-
-{%- for chain_name, chain in chains.iteritems() %}
-{%- for rule in meta_rules + chain.rules %}
-{%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv6' %}
-{%- set r = {
-  'full': 'True',
-  'table': 'filter',
-  'chain': chain_name.upper(),
-  'command': 'A',
-  'family': 'ipv6',
-  'comment': rule.get('comment', '') + '__saltstack__',
-} %}
-{%- if rule.position is defined %}
-{%- do r.update({
-  'command': 'I',
-  'position': rule['position'],
-}) %}
-{%- endif %}
-{%- if rule.jump is defined %}
-{%- do r.update({'jump': rule.jump}) %}
-{%- endif %}
-{%- if rule.match is defined %}
-{%- do r.update({'match': rule.match}) %}
-{%- endif %}
-{%- if rule.connection_state is defined %}
-{%- do r.update({'connstate': rule.connection_state}) %}
-{%- endif %}
-{%- if rule.protocol is defined %}
-{%- do r.update({'proto': rule.protocol}) %}
-{%- endif %}
-{%- if rule.destination_port is defined %}
-{%- do r.update({'dport': rule.destination_port}) %}
-{%- endif %}
-{%- if rule.source_port is defined %}
-{%- do r.update({'sport': rule.source_port}) %}
-{%- endif %}
-{%- if rule.in_interface is defined %}
-{%- do r.update({'in-interface': rule.in_interface}) %}
-{%- endif %}
-{%- if rule.out_interface is defined %}
-{%- do r.update({'out-interface': rule.out_interface}) %}
-{%- endif %}
-{%- if rule.to_destination is defined %}
-{%- do r.update({'to-destination': rule.to_destination}) %}
-{%- endif %}
-{%- if rule.to_port is defined %}
-{%- do r.update({'to-port': rule.to_port}) %}
-{%- endif %}
-{%- if rule.to_source is defined %}
-{%- do r.update({'to-source': rule.to_source}) %}
-{%- endif %}
-{%-  if rule.source_network is defined %}
-{%- do r.update({'source': rule.source_network}) %}
-{%- endif %}
-{%-  if rule.destination_network is defined %}
-{%- do r.update({'destination': rule.destination_network}) %}
-{%- endif %}
-{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t filter ', '') }}
-{%- endif %}
-{%- endfor %}
-{%- endfor %}
-COMMIT
-
-*nat
+*{{ table }}
 {%- for chain_name, chain in chains.iteritems() %}
 :{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
 {%- endfor %}
 
 {%- for chain_name, chain in chains.iteritems() %}
 {%- for rule in chain.rules %}
-{%- if rule.get('table', 'filter').lower() == 'nat' and rule.get('family', 'ipv4') == 'ipv6' %}
+{%- if rule.get('table', 'filter').lower() == table and rule.get('family', 'ipv4') == 'ipv6' %}
 {%- set r = {
   'full': 'True',
-  'table': 'nat',
+  'table': table,
   'chain': chain_name.upper(),
   'command': 'A',
   'family': 'ipv6',
@@ -122,14 +56,21 @@ COMMIT
 {%- if rule.to_source is defined %}
 {%- do r.update({'to-source': rule.to_source}) %}
 {%- endif %}
-{%-  if rule.source_network is defined %}
+{%- if rule.source_network is defined %}
 {%- do r.update({'source': rule.source_network}) %}
 {%- endif %}
-{%-  if rule.destination_network is defined %}
+{%- if rule.destination_network is defined %}
 {%- do r.update({'destination': rule.destination_network}) %}
 {%- endif %}
-{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t nat ', '') }}
+{%- if rule.mark is defined %}
+{%- do r.update({'mark': rule.mark}) %}
+{%- endif %}
+{%- if rule.set_mark is defined %}
+{%- do r.update({'set-mark': rule.set_mark}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t %s ' % table, '') }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
 COMMIT
+{%- endfor %}

--- a/iptables/files/rules.v6
+++ b/iptables/files/rules.v6
@@ -1,0 +1,135 @@
+# This file is managed by SaltStack
+
+*filter
+{%- for chain_name, chain in chains.iteritems() %}
+:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
+{%- endfor %}
+
+{%- for chain_name, chain in chains.iteritems() %}
+{%- for rule in chain.rules %}
+{%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv6' %}
+{%- set r = {
+  'full': 'True',
+  'table': 'filter',
+  'chain': chain_name.upper(),
+  'command': 'A',
+  'family': 'ipv6',
+  'comment': rule.get('comment', '') + '__saltstack__',
+} %}
+{%- if rule.position is defined %}
+{%- do r.update({
+  'command': 'I',
+  'position': rule['position'],
+}) %}
+{%- endif %}
+{%- if rule.jump is defined %}
+{%- do r.update({'jump': rule.jump}) %}
+{%- endif %}
+{%- if rule.match is defined %}
+{%- do r.update({'match': rule.match}) %}
+{%- endif %}
+{%- if rule.connection_state is defined %}
+{%- do r.update({'connstate': rule.connection_state}) %}
+{%- endif %}
+{%- if rule.protocol is defined %}
+{%- do r.update({'proto': rule.protocol}) %}
+{%- endif %}
+{%- if rule.destination_port is defined %}
+{%- do r.update({'dport': rule.destination_port}) %}
+{%- endif %}
+{%- if rule.source_port is defined %}
+{%- do r.update({'sport': rule.source_port}) %}
+{%- endif %}
+{%- if rule.in_interface is defined %}
+{%- do r.update({'in-interface': rule.in_interface}) %}
+{%- endif %}
+{%- if rule.out_interface is defined %}
+{%- do r.update({'out-interface': rule.out_interface}) %}
+{%- endif %}
+{%- if rule.to_destination is defined %}
+{%- do r.update({'to-destination': rule.to_destination}) %}
+{%- endif %}
+{%- if rule.to_port is defined %}
+{%- do r.update({'to-port': rule.to_port}) %}
+{%- endif %}
+{%- if rule.to_source is defined %}
+{%- do r.update({'to-source': rule.to_source}) %}
+{%- endif %}
+{%-  if rule.source_network is defined %}
+{%- do r.update({'source': rule.source_network}) %}
+{%- endif %}
+{%-  if rule.destination_network is defined %}
+{%- do r.update({'destination': rule.destination_network}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t filter ', '') }}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+COMMIT
+
+*nat
+{%- for chain_name, chain in chains.iteritems() %}
+:{{ chain_name | upper }} {{ chain.get('policy', '-') | upper }}
+{%- endfor %}
+
+{%- for chain_name, chain in chains.iteritems() %}
+{%- for rule in chain.rules %}
+{%- if rule.get('table', 'filter').lower() == 'nat' and rule.get('family', 'ipv4') == 'ipv6' %}
+{%- set r = {
+  'full': 'True',
+  'table': 'nat',
+  'chain': chain_name.upper(),
+  'command': 'A',
+  'family': 'ipv6',
+  'comment': rule.get('comment', '') + '__saltstack__',
+} %}
+{%- if rule.position is defined %}
+{%- do r.update({
+  'command': 'I',
+  'position': rule['position'],
+}) %}
+{%- endif %}
+{%- if rule.jump is defined %}
+{%- do r.update({'jump': rule.jump}) %}
+{%- endif %}
+{%- if rule.match is defined %}
+{%- do r.update({'match': rule.match}) %}
+{%- endif %}
+{%- if rule.connection_state is defined %}
+{%- do r.update({'connstate': rule.connection_state}) %}
+{%- endif %}
+{%- if rule.protocol is defined %}
+{%- do r.update({'proto': rule.protocol}) %}
+{%- endif %}
+{%- if rule.destination_port is defined %}
+{%- do r.update({'dport': rule.destination_port}) %}
+{%- endif %}
+{%- if rule.source_port is defined %}
+{%- do r.update({'sport': rule.source_port}) %}
+{%- endif %}
+{%- if rule.in_interface is defined %}
+{%- do r.update({'in-interface': rule.in_interface}) %}
+{%- endif %}
+{%- if rule.out_interface is defined %}
+{%- do r.update({'out-interface': rule.out_interface}) %}
+{%- endif %}
+{%- if rule.to_destination is defined %}
+{%- do r.update({'to-destination': rule.to_destination}) %}
+{%- endif %}
+{%- if rule.to_port is defined %}
+{%- do r.update({'to-port': rule.to_port}) %}
+{%- endif %}
+{%- if rule.to_source is defined %}
+{%- do r.update({'to-source': rule.to_source}) %}
+{%- endif %}
+{%-  if rule.source_network is defined %}
+{%- do r.update({'source': rule.source_network}) %}
+{%- endif %}
+{%-  if rule.destination_network is defined %}
+{%- do r.update({'destination': rule.destination_network}) %}
+{%- endif %}
+{{ salt['iptables.build_rule'](**r) | regex_replace('^.*-t nat ', '') }}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+COMMIT

--- a/iptables/files/rules.v6
+++ b/iptables/files/rules.v6
@@ -6,7 +6,7 @@
 {%- endfor %}
 
 {%- for chain_name, chain in chains.iteritems() %}
-{%- for rule in chain.rules %}
+{%- for rule in meta_rules + chain.rules %}
 {%- if rule.get('table', 'filter').lower() == 'filter' and rule.get('family', 'ipv4') == 'ipv6' %}
 {%- set r = {
   'full': 'True',

--- a/iptables/map.jinja
+++ b/iptables/map.jinja
@@ -1,7 +1,7 @@
 
 {% set service = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['iptables','iptables-persistent' ],
+        'pkgs': ['iptables','netfilter-persistent' ],
         'service': 'netfilter-persistent',
     },
     'RedHat': {

--- a/iptables/map.jinja
+++ b/iptables/map.jinja
@@ -1,15 +1,19 @@
 
 {% set service = salt['grains.filter_by']({
     'Debian': {
-        'pkgs': ['iptables','netfilter-persistent' ],
+        'pkgs': ['iptables','netfilter-persistent'],
         'service': 'netfilter-persistent',
+        'providers': ['iptables-restore'],
     },
     'RedHat': {
         'pkgs': ['iptables'],
         'service': 'iptables',
+        'providers': [],
     },
 }, merge=salt['grains.filter_by']({
     'trusty': {
+        'pkgs': ['iptables','iptables-persistent'],
         'service': 'iptables-persistent',
+        'providers': [],
     },
 }, grain='oscodename', merge=salt['pillar.get']('iptables:service'))) %}

--- a/iptables/rules.sls
+++ b/iptables/rules.sls
@@ -1,17 +1,19 @@
 {% from "iptables/map.jinja" import service with context %}
 {%- if grains.get('virtual_subtype', None) not in ['Docker', 'LXC'] %}
 
-{%- if grains.os_family == 'Debian' and service.get('provider') == "iptables-restore" %}
+{%- if 'iptables-restore' in service.providers and service.get('provider') == "iptables-restore" %}
 
 {%- set meta_rules = [] %}
-{%- for service_name, service in pillar.items() %}
-{%- if service.get('_support', {}).get('iptables', {}).get('enabled', False) %}
+{%- for service_name, meta_service in pillar.items() %}
+{%- if meta_service is mapping %}
+{%- if meta_service.get('_support', {}).get('iptables', {}).get('enabled', False) %}
 
 {%- set grains_fragment_file = service_name+'/meta/iptables.yml' %}
 {%- macro load_grains_file() %}{% include grains_fragment_file %}{% endmacro %}
 {%- set grains_yaml = load_grains_file()|load_yaml %}
 {%- set meta_rules = meta_rules + grains_yaml.iptables.rules %}
 
+{%- endif %}
 {%- endif %}
 {%- endfor %}
 /etc/iptables/rules.v4.tmp:

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -9,7 +9,7 @@ iptables_packages:
   pkg.installed:
   - names: {{ service.pkgs }}
 
-{%- if grains.os_family == 'Debian' %}
+{%- if 'iptables-restore' in service.providers %}
 /usr/share/netfilter-persistent/plugins.d/15-ip4tables:
   file.managed:
     - source: salt://iptables/files/ip4tables

--- a/iptables/service.sls
+++ b/iptables/service.sls
@@ -9,6 +9,31 @@ iptables_packages:
   pkg.installed:
   - names: {{ service.pkgs }}
 
+{%- if grains.os_family == 'Debian' %}
+/usr/share/netfilter-persistent/plugins.d/15-ip4tables:
+  file.managed:
+    - source: salt://iptables/files/ip4tables
+    - mode: 755
+    - template: jinja
+    - defaults:
+        provider: {{ service.get('provider') }}
+    - require:
+      - pkg: iptables_packages
+    - watch_in:
+      - service: iptables_services
+/usr/share/netfilter-persistent/plugins.d/25-ip6tables:
+  file.managed:
+    - source: salt://iptables/files/ip6tables
+    - mode: 755
+    - template: jinja
+    - defaults:
+        provider: {{ service.get('provider') }}
+    - require:
+      - pkg: iptables_packages
+    - watch_in:
+      - service: iptables_services
+{%- endif %}
+
 iptables_services:
 {%- if grains.init == 'systemd' %}
   service.running:


### PR DESCRIPTION
This will not save or flush current iptables rules so that it makes the iptables-restore provider compatible with docker or similar software that manage their own rules in iptables.