### PR TITLE
Fix for python3

### DIFF
--- a/_modules/iptables_extra.py
+++ b/_modules/iptables_extra.py
@@ -22,7 +22,7 @@ def get_tables(family="ipv4"):
     try:
         tables_list = Popen(cmd, shell=True, stdout=PIPE)
         while True:
-            line = tables_list.stdout.readline()
+            line = tables_list.stdout.readline().decode()
             if line != '':
                 if line[0] == "*":
                     tables.append(line.rstrip()[1:])


### PR DESCRIPTION
get_tables was failing with python3, because readline() returns bytes, which is always distinct to '', but then it failed with IndexError for empty lines. Also, line[0] was returning 42 instead of '*', so no table would be returned.

I have tested with python2 too, and decode() can be called there, it will return unicode type, and comparing with '' and '*' works